### PR TITLE
Update documentation for cross-node parallelism

### DIFF
--- a/doc/source/data/working-with-llms.rst
+++ b/doc/source/data/working-with-llms.rst
@@ -227,26 +227,49 @@ to turn it off.
 Frequently Asked Questions (FAQs)
 --------------------------------------------------
 
-.. TODO(#55491): Rewrite this section once the restriction is lifted.
-.. TODO(#55405): Cross-node TP in progress.
 .. _cross_node_parallelism:
 
 How to configure LLM stage to parallelize across multiple nodes?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-At the moment, Ray Data LLM doesn't support cross-node parallelism (either
-tensor parallelism or pipeline parallelism).
+Ray Data LLM now supports cross-node parallelism for both tensor parallelism (TP) 
+and pipeline parallelism (PP). By default, Ray Data uses the 
+`PACK strategy <https://docs.ray.io/en/latest/ray-core/scheduling/placement-group.html#pgroup-strategy>`_, 
+which attempts to place all resources on a single node when possible, but 
+allows cross-node placement if a single node doesn't have enough resources.
 
-The processing pipeline is designed to run on a single node. The number of
-GPUs is calculated as the product of the tensor parallel size and the pipeline
-parallel size, and apply
-[`STRICT_PACK` strategy](https://docs.ray.io/en/latest/ray-core/scheduling/placement-group.html#pgroup-strategy)
-to ensure that each replica of the LLM stage is executed on a single node.
+For explicit control over cross-node placement, you can specify a custom 
+``placement_group_config`` with a ``SPREAD`` or ``STRICT_SPREAD`` strategy:
 
-Nevertheless, you can still horizontally scale the LLM stage to multiple nodes
-as long as each replica (TP * PP) fits into a single node. The number of
-replicas is configured by the `concurrency` argument in
-:class:`vLLMEngineProcessorConfig <ray.data.llm.vLLMEngineProcessorConfig>`.
+.. code-block:: python
+
+    from ray.data.llm import build_llm_processor, vLLMEngineProcessorConfig
+
+    # Example: Force cross-node TP with SPREAD strategy
+    config = vLLMEngineProcessorConfig(
+        model="meta-llama/Meta-Llama-3.1-70B-Instruct",
+        concurrency=1,
+        engine_kwargs={
+            "tensor_parallel_size": 8,
+            "distributed_executor_backend": "ray",  # Required for cross-node TP/PP
+        },
+        placement_group_config={
+            "bundles": [{"GPU": 1, "CPU": 1}] * 8,  # 8 bundles for TP=8
+            "strategy": "SPREAD",  # Spread across nodes
+        },
+    )
+    processor = build_llm_processor(config)
+
+**Important notes:**
+
+- Cross-node TP/PP requires setting ``distributed_executor_backend="ray"`` in ``engine_kwargs``
+- Each bundle in ``placement_group_config`` must specify at most one GPU for the ray executor backend
+- The default ``PACK`` strategy provides good performance for most use cases
+- Use ``SPREAD`` or ``STRICT_SPREAD`` only when you specifically need cross-node distribution
+
+You can also horizontally scale the LLM stage to multiple nodes by increasing 
+the ``concurrency`` argument in :class:`vLLMEngineProcessorConfig <ray.data.llm.vLLMEngineProcessorConfig>`.
+Each replica will run independently with its own TP/PP configuration.
 
 .. _gpu_memory_management:
 


### PR DESCRIPTION
## Description

This PR updates the Ray Data LLM documentation to reflect that cross-node tensor parallelism (TP) and pipeline parallelism (PP) are now supported. The previous documentation stated that cross-node parallelism was not supported.

The changes include:
- Removing outdated statements about the lack of cross-node parallelism.
- Clarifying that cross-node TP/PP is supported (as enabled by #56779).
- Explaining the default `PACK` placement strategy and its behavior for cross-node placement.
- Providing a code example demonstrating how to explicitly configure cross-node placement using the `SPREAD` strategy with `placement_group_config`.
- Adding important notes regarding `distributed_executor_backend` and bundle configuration for cross-node setups.

## Related issues

Related to #56779 (which enabled cross-node parallelism).
Context from Slack thread: [https://ray-project.slack.com/archives/C037996329H/p1701047609756689](https://ray-project.io/slack)

## Types of change

- [ ] Bug fix 🐛
- [ ] New feature ✨
- [ ] Enhancement 🚀
- [ ] Code refactoring 🔧
- [x] Documentation update 📖
- [ ] Chore 🧹
- [ ] Style 🎨

## Checklist

**Does this PR introduce breaking changes?**
- [ ] Yes ⚠️
- [x] No

**Testing:**
- [ ] Added/updated tests for my changes
- [x] Tested the changes manually
- [ ] This PR is not tested ❌ _(please explain why)_

**Code Quality:**
- [x] Signed off every commit (`git commit -s`)
- [x] Ran pre-commit hooks ([setup guide](https://docs.ray.io/en/latest/ray-contribute/getting-involved.html#lint-and-formatting))

**Documentation:**
- [x] Updated documentation (if applicable) ([contribution guide](https://docs.ray.io/en/latest/ray-contribute/docs.html))
- [ ] Added new APIs to `doc/source/` (if applicable)

## Additional context

The documentation now accurately reflects the current capabilities of Ray Data LLM for large model inference across multiple nodes.

---
[Slack Thread](https://anyscaleteam.slack.com/archives/C01DF0FR40P/p1761354809196679?thread_ts=1761354809.196679&cid=C01DF0FR40P)

<a href="https://cursor.com/background-agent?bcId=bc-c42827da-1dba-4abf-a2dc-f1b40d87550d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c42827da-1dba-4abf-a2dc-f1b40d87550d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

